### PR TITLE
API base URL defaults to production

### DIFF
--- a/src/services/ApiBaseService.ts
+++ b/src/services/ApiBaseService.ts
@@ -3,18 +3,18 @@ import { ArgumentNullException } from "../common/Exceptions";
 
 export interface ConfigurationOptions {
     apiKey?: string;
-    baseUrl: string;
+    baseUrl?: string;
 }
 
 export class Configuration implements ConfigurationOptions {
     // API_KEY may or may not be needed in the future.
     // so far only supporting authentication with user credentials
     public apiKey?: string;
-    public baseUrl: string;
+    public baseUrl: string = "https://api.devopness.com";
 
     constructor(options: ConfigurationOptions) {
         this.apiKey = options.apiKey;
-        this.baseUrl = options.baseUrl;
+        this.baseUrl = options.baseUrl || this.baseUrl;
     }
 }
 

--- a/src/services/ApiBaseService.ts
+++ b/src/services/ApiBaseService.ts
@@ -10,7 +10,7 @@ export class Configuration implements ConfigurationOptions {
     // API_KEY may or may not be needed in the future.
     // so far only supporting authentication with user credentials
     public apiKey?: string;
-    public baseUrl: string = "https://api.devopness.com";
+    public baseUrl = "https://api.devopness.com";
 
     constructor(options: ConfigurationOptions) {
         this.apiKey = options.apiKey;


### PR DESCRIPTION
* `baseUrl` field in `ConfigurationOptions` is optional.
* `baseUrl` field in `Configuration` defaults to `"https://api.devopness.com"`