### PR TITLE
Error common ancestor

### DIFF
--- a/src/DevopnessApiClient.ts
+++ b/src/DevopnessApiClient.ts
@@ -34,14 +34,6 @@ export class DevopnessApiClient {
   static: StaticService;
   users: UserService;
 
-  /**
-   * @todo provide a global onError event? How to make it easy to clients to interact with
-   * this SDK without being dependant themselves on AxiosResponse types?
-   * We should be the only ones concerned about axios and moving from
-   * Axios to another HTTP library should not affect the consumers
-   * of this SDK
-   */
-
   constructor(options?: ConfigurationOptions) {
     ApiBaseService.configuration = new Configuration(options || {});
 

--- a/src/common/Exceptions.ts
+++ b/src/common/Exceptions.ts
@@ -1,8 +1,13 @@
 import { AxiosError, AxiosResponse } from 'axios'
 
-export class ArgumentNullException extends Error {
+export class DevopnessSdkError extends Error {
+    constructor(message?: string) {
+        super(`Devopness SDK Error - ${message}`);
+    }
+}
+
+export class ArgumentNullException extends DevopnessSdkError {
     constructor(public param: string, method?: string, msg?: string) {
-        // TO DO: check if it's possible to use reflection/prototype to retrieve the method name
         super(msg || `Value cannot be null. Missing required parameter: "${param}" when calling "${method}"`);
     }
 }
@@ -12,13 +17,13 @@ export interface ErrorResponseData {
     errors?: Array<Record<string, string>>;
 }
 
-export class NetworkError extends Error {
+export class NetworkError extends DevopnessSdkError {
     constructor(error: AxiosError) {
         super(error.message);
     }
 }
 
-export class ApiError<T> extends Error {
+export class ApiError<T> extends DevopnessSdkError {
     errors?: Array<Record<string, string>>;
     response?: AxiosResponse<T>;
     status: number;

--- a/src/common/Exceptions.ts
+++ b/src/common/Exceptions.ts
@@ -1,12 +1,12 @@
 import { AxiosError, AxiosResponse } from 'axios'
 
-export class DevopnessSdkError extends Error {
+export class SdkError extends Error {
     constructor(message?: string) {
         super(`Devopness SDK Error - ${message}`);
     }
 }
 
-export class ArgumentNullException extends DevopnessSdkError {
+export class ArgumentNullException extends SdkError {
     constructor(public param: string, method?: string, msg?: string) {
         super(msg || `Value cannot be null. Missing required parameter: "${param}" when calling "${method}"`);
     }
@@ -17,13 +17,13 @@ export interface ErrorResponseData {
     errors?: Array<Record<string, string>>;
 }
 
-export class NetworkError extends DevopnessSdkError {
+export class NetworkError extends SdkError {
     constructor(error: AxiosError) {
         super(error.message);
     }
 }
 
-export class ApiError<T> extends DevopnessSdkError {
+export class ApiError<T> extends SdkError {
     errors?: Array<Record<string, string>>;
     response?: AxiosResponse<T>;
     status: number;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export * from './DevopnessApiClient';
-export * as DevopnessSdkExceptions from './common/Exceptions';
-export * as DevopnessSdkModels from './api/generated/models';
+export * as SdkExceptions from './common/Exceptions';
+export * as SdkModels from './api/generated/models';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export * from './DevopnessApiClient';
 export * as DevopnessSdkExceptions from './common/Exceptions';
-export * from './api/generated/models';
+export * as DevopnessSdkModels from './api/generated/models';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from './DevopnessApiClient';
+export * as DevopnessSdkExceptions from './common/Exceptions';
 export * from './api/generated/models';

--- a/src/services/ApiBaseService.ts
+++ b/src/services/ApiBaseService.ts
@@ -59,15 +59,15 @@ export class ApiBaseService {
     }
 
     private setUserAgent(): void {
-        // Firefox is fine with setting the 'User-Agent' header, but Chrome/Safari are not.
+        // Firefox is fine with setting the 'User-Agent' header, but Chrome and Safari are not.
         // As we don't want Chrome to raise piles of console logs with the error message:
         // 'Refused to set unsafe header "User-Agent"', we then only set the UA header
         // when the SDK is not being consumed from an app running on a browser foreground.
         // i.e: node.js cli, node.js server side, web workers, ...
         // if a window object is defined then we're very likely on a browser
         // so we don't set a custom User-Agent header
-        const devopnessSdkRunningOnBrowserForeground = typeof window !== 'undefined';
-        if (!devopnessSdkRunningOnBrowserForeground) {
+        const runningOnBrowserForeground = typeof window !== 'undefined';
+        if (!runningOnBrowserForeground) {
             // Setting the `User-Agent` with SDK version so we can track SDK adoption
             // through requests sent through it hitting our API servers
             this.api.defaults.headers.common['User-Agent'] = `devopness-sdk-js/${ApiBaseService.SDK_VERSION}`;

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -1,11 +1,4 @@
 import { UsersApiService } from '../api/generated/apis/users-api';
 
 export class UserService extends UsersApiService {
-    /**
-     * We auto-generate api proxy classes automatically, but it's safer to have control over exposed
-     * services and methods, hence this public service class extends the generated classes, so we
-     * can intercept, override or even hide generated methods.
-     *
-     * @todo: move services to `public` folder
-     */
 }


### PR DESCRIPTION
This PR attempts to make it easier for consumers to import SDK export classes.
**Main changes:**

1. Define a base `DevopnessSdkError` class and ensure all custom SDK errors extend this base type
2. Export all SDK error classes so consumers can handle them gracefully by checking the specific error types:
```javascript

if (error instanceof DevopnessSdkExceptions.NetworkError) {
   // handle network error
}

if (error instanceof DevopnessSdkExceptions.ApiError) {
   // handle Devopness API error
}

// or generically 
if (error instanceof DevopnessSdkExceptions.DevopnessSdkError) {
   // common handler for all Devopness API SDK errors
}

```
3. Use named exports for `Models`, so consumer can import `Models` or `Models.ModelName` and make their code a bit cleaner and readable