### PR TITLE
Feature/DFE-628 update SDK to load DOM builtin library

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "lib": [
-      "ES2015"
+      "ES2015",
+      "DOM"
     ],
     "allowJs": false,
     "declaration": true,


### PR DESCRIPTION
The Axios `0.20.0` requires the usage of `ProgressEvent` that is declared at `DOM` builtin library of TypeScript.