### PR TITLE
Feat/DFE-779 add pageCount to ApiResponse

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1338,6 +1338,11 @@
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
     },
+    "@types/parse-link-header": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse-link-header/-/parse-link-header-1.0.0.tgz",
+      "integrity": "sha512-fCA3btjE7QFeRLfcD0Sjg+6/CnmC66HpMBoRfRzd2raTaWMJV21CCZ0LO8MOqf8onl5n0EPfjq4zDhbyX8SVwA=="
+    },
     "@types/prettier": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.0.2.tgz",
@@ -6171,6 +6176,14 @@
         "error-ex": "^1.2.0"
       }
     },
+    "parse-link-header": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-1.0.1.tgz",
+      "integrity": "sha1-vt/g0hGK64S+deewJUGeyKYRQKc=",
+      "requires": {
+        "xtend": "~4.0.1"
+      }
+    },
     "parse5": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
@@ -7810,6 +7823,11 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,8 @@
     "typescript": "^4.0.2"
   },
   "dependencies": {
-    "axios": "^0.20.0"
+    "@types/parse-link-header": "^1.0.0",
+    "axios": "^0.20.0",
+    "parse-link-header": "^1.0.1"
   }
 }

--- a/src/common/ApiResponse.ts
+++ b/src/common/ApiResponse.ts
@@ -1,11 +1,22 @@
 import { AxiosResponse } from 'axios'
+import parseLinkHeader from 'parse-link-header'
+
+interface ApiLinks {
+    last: {
+        page: number;
+    }
+}
 
 export class ApiResponse<T>{
-    status: number;
     data: T;
+    pageCount?: number;
+    status: number;
 
     constructor(axiosResp: AxiosResponse<T>) {
         this.status = axiosResp.status;
         this.data = axiosResp.data;
+
+        const linkHeader = parseLinkHeader(axiosResp.headers?.link) as ApiLinks | null;
+        this.pageCount = Number(linkHeader?.last.page) || undefined;
     }
 }

--- a/src/common/ApiResponse.ts
+++ b/src/common/ApiResponse.ts
@@ -17,6 +17,6 @@ export class ApiResponse<T>{
         this.data = axiosResp.data;
 
         const linkHeader = parseLinkHeader(axiosResp.headers?.link) as ApiLinks | null;
-        this.pageCount = Number(linkHeader?.last.page) || undefined;
+        this.pageCount = Number(linkHeader?.last?.page) || undefined;
     }
 }

--- a/tests/ApiResponse.spec.ts
+++ b/tests/ApiResponse.spec.ts
@@ -3,22 +3,22 @@ import { ApiResponse } from '../src/common/ApiResponse';
 
 test('ApiResponse has the correct pageCount value', () => {
     const baseUrl = 'https://test.com/path';
-    const expectedPage = 7;
+    const expectedPageCount = 7;
 
     const axiosResponse = {
         data: null,
         status: 200,
         headers: {
-            link: `<${baseUrl}?page=1>; rel="first", <${baseUrl}?page=${expectedPage}>; rel="last"`,
+            link: `<${baseUrl}?page=1>; rel="first", <${baseUrl}?page=${expectedPageCount}>; rel="last"`,
         },
     } as AxiosResponse<null>;
 
     const response = new ApiResponse<null>(axiosResponse);
 
-    expect(response.pageCount).toBe(expectedPage);
+    expect(response.pageCount).toBe(expectedPageCount);
 });
 
-test('ApiResponse do not fail if no have Link header', () => {
+test('ApiResponse do not fail if no Link header present', () => {
     const axiosResponse = {
         data: null,
         status: 200,

--- a/tests/ApiResponse.spec.ts
+++ b/tests/ApiResponse.spec.ts
@@ -17,3 +17,29 @@ test('ApiResponse has the correct pageCount value', () => {
 
     expect(response.pageCount).toBe(expectedPage);
 });
+
+test('ApiResponse do not fail if no have Link header', () => {
+    const axiosResponse = {
+        data: null,
+        status: 200,
+        headers: {},
+    } as AxiosResponse<null>;
+
+    const response = new ApiResponse<null>(axiosResponse);
+
+    expect(response.pageCount).toBe(undefined);
+});
+
+test('If no have last link, expect undefined pageCount', () => {
+    const axiosResponse = {
+        data: null,
+        status: 200,
+        headers: {
+            link: `<https://test.com/path?page=1>; rel="first"`,
+        },
+    } as AxiosResponse<null>;
+
+    const response = new ApiResponse<null>(axiosResponse);
+
+    expect(response.pageCount).toBe(undefined);
+});

--- a/tests/ApiResponse.spec.ts
+++ b/tests/ApiResponse.spec.ts
@@ -1,0 +1,19 @@
+import { AxiosResponse } from 'axios';
+import { ApiResponse } from '../src/common/ApiResponse';
+
+test('ApiResponse has the correct pageCount value', () => {
+    const baseUrl = 'https://test.com/path';
+    const expectedPage = 7;
+
+    const axiosResponse = {
+        data: null,
+        status: 200,
+        headers: {
+            link: `<${baseUrl}?page=1>; rel="first", <${baseUrl}?page=${expectedPage}>; rel="last"`,
+        },
+    } as AxiosResponse<null>;
+
+    const response = new ApiResponse<null>(axiosResponse);
+
+    expect(response.pageCount).toBe(expectedPage);
+});


### PR DESCRIPTION
This PR add `pageCount` attribute to `ApiResponse` class. The value is retrieved from the link `last` from `Link` header.