### PR TITLE
feat: add get logs to service 'start' and 'stop' actions

### DIFF
--- a/src/api/generated/apis/logs-api.ts
+++ b/src/api/generated/apis/logs-api.ts
@@ -90,6 +90,22 @@ export class LogsApiService extends ApiBaseService {
 
     /**
      * 
+     * @summary Get service start log
+     * @param {number} serviceId The unique id of the service
+     */
+    public async getServiceStartLog(serviceId: number): Promise<ApiResponse<Log>> {
+        if (serviceId === null || serviceId === undefined) {
+            throw new ArgumentNullException('serviceId', 'getServiceStartLog');
+        }
+        const queryString = [].join('&');
+        const requestUrl = '/logs/service/{service_id}/start' + (queryString? `?${queryString}` : '');
+
+        const response = await this.get <Log>(requestUrl.replace(`{${"service_id"}}`, encodeURIComponent(String(serviceId))));
+        return new ApiResponse(response);
+    }
+
+    /**
+     * 
      * @summary Get service status log
      * @param {number} serviceId The unique id of the service
      */
@@ -99,6 +115,22 @@ export class LogsApiService extends ApiBaseService {
         }
         const queryString = [].join('&');
         const requestUrl = '/logs/service/{service_id}/status' + (queryString? `?${queryString}` : '');
+
+        const response = await this.get <Log>(requestUrl.replace(`{${"service_id"}}`, encodeURIComponent(String(serviceId))));
+        return new ApiResponse(response);
+    }
+
+    /**
+     * 
+     * @summary Get service stop log
+     * @param {number} serviceId The unique id of the service
+     */
+    public async getServiceStopLog(serviceId: number): Promise<ApiResponse<Log>> {
+        if (serviceId === null || serviceId === undefined) {
+            throw new ArgumentNullException('serviceId', 'getServiceStopLog');
+        }
+        const queryString = [].join('&');
+        const requestUrl = '/logs/service/{service_id}/stop' + (queryString? `?${queryString}` : '');
 
         const response = await this.get <Log>(requestUrl.replace(`{${"service_id"}}`, encodeURIComponent(String(serviceId))));
         return new ApiResponse(response);

--- a/src/api/spec.json
+++ b/src/api/spec.json
@@ -1191,10 +1191,102 @@
         }
       }
     },
+    "/logs/service/{service_id}/start": {
+      "get": {
+        "summary": "Get service start log",
+        "operationId": "getServiceStartLog",
+        "tags": [
+          "Logs"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/acceptHeader"
+          },
+          {
+            "$ref": "#/components/parameters/authHeader"
+          },
+          {
+            "$ref": "#/components/parameters/contentTypeHeader"
+          },
+          {
+            "in": "path",
+            "name": "service_id",
+            "example": 1,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "required": true,
+            "description": "The unique id of the service"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Log"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
     "/logs/service/{service_id}/status": {
       "get": {
         "summary": "Get service status log",
         "operationId": "getServiceStatusLog",
+        "tags": [
+          "Logs"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/acceptHeader"
+          },
+          {
+            "$ref": "#/components/parameters/authHeader"
+          },
+          {
+            "$ref": "#/components/parameters/contentTypeHeader"
+          },
+          {
+            "in": "path",
+            "name": "service_id",
+            "example": 1,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "required": true,
+            "description": "The unique id of the service"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Log"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/logs/service/{service_id}/stop": {
+      "get": {
+        "summary": "Get service stop log",
+        "operationId": "getServiceStopLog",
         "tags": [
           "Logs"
         ],


### PR DESCRIPTION
Update SDK adding `getServiceStartLog` and `getServiceStopLog` operations.