### PR TITLE
feat: update configurations

### DIFF
--- a/openapitools.json
+++ b/openapitools.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "node_modules/@openapitools/openapi-generator-cli/config.schema.json",
+  "spaces": 2,
+  "generator-cli": {
+    "version": "4.3.1",
+    "generators": {
+      "build-api-models": {
+        "generatorName": "typescript-axios",
+        "glob": "./src/api/*.json",
+        "templateDir": "./src/api/generator/templates",
+        "output": "./src/api",
+        "apiPackage": "generated/apis",
+        "modelPackage": "generated/models",
+        "skipValidateSpec": true,
+        "minimalUpdate": true,
+        "additionalProperties": {
+          "withSeparateModelsAndApi": true,
+          "supportsES6": false
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "rm -R ./dist || true && npm run lint && tsc",
-    "build-api-models": "rm -R ./src/api/generated || true && JAVA_OPTS=\"${JAVA_OPTS} -Dlog.level=warn\" openapi-generator generate --template-dir ./src/api/generator/templates --skip-validate-spec --minimal-update -i ./src/api/spec.json -g typescript-axios -o ./src/api -p withSeparateModelsAndApi=true --api-package generated/apis --model-package generated/models --additional-properties supportsES6=false && npm run build",
+    "build": "rm -Rf ./dist && npm run lint && tsc",
+    "build-api-models": "rm -Rf ./src/api/generated && JAVA_OPTS=\"${JAVA_OPTS} -Dlog.level=warn\" openapi-generator-cli generate && npm run build",
     "lint": "eslint . --ext .ts",
     "prepublishOnly": "npm test",
     "prepare": "npm run build",


### PR DESCRIPTION
- Update `build-api-models` script to be compatible with new `openapi-generator-cli` version.
- Add `openapitools.json` configuration file with the options to build API models.
- Improvements on scripts that delete folders. Using `-f` option the `rm` doesn't fail if the folder/file doesn't exist ([ref]).

[ref]: https://man7.org/linux/man-pages/man1/rm.1.html