### PR TITLE
docs: Add `Building and testing` section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,24 @@ This package includes TypeScript declarations for every method.
 TypeScript versions `>= 3.8` are supported.
 
 Some methods in `Devopness SDK JavaScript` accept and return objects from the Devopness API. The type declarations for these objects will always track the latest version of the API. Therefore, if you'e using the latest version of this package you can rely on the Devopness API documentation for checking the input and return types of each API endpoint.
+
+## Building and testing
+To build and test the SDK locally, follow these steps:
+1. Clone de repository
+```
+git clone https://github.com/devopness/devopness-sdk-js.git
+```
+2. Install missing dependencies
+
+This command will install all modules listed as dependencies in [package.json](package.json). A working Java Runtime Environment is also required. Please, check out the installation instructions for your operating system.
+```
+npm install
+```
+3. Build
+```
+npm run build-api-models
+```
+4. Run tests
+```
+npm run test
+```


### PR DESCRIPTION
This PR adds instructions to build and test the Devopness SDK locally.