### PR TITLE
refactor: Output auto-generated docs to SDK specific folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,5 +103,5 @@ dist
 # TernJS port file
 .tern-port
 
-# Documentation
-/docs
+# Auto-generated documentation
+docs-sdk-js

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,5 +1,5 @@
 {
-  "out": "docs",
+  "out": "docs-sdk-js",
   "entryPoints": [
     "src/index.ts",
     "src/services"


### PR DESCRIPTION
Output auto-generated docs to SDK specific `/docs-sdk-*` folder, leaving root `/docs` folder reserved for official documentation to be written by this repo contributors.