### PR TITLE
ci: Add linter to validate PR attributes

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,0 +1,17 @@
+name: "Lint PR"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,8 +1,9 @@
 name: "Lint PR"
 
 on:
-  # pull_request_target:
-  pull_request:
+  # pull_request:
+  # triggers on `pull_request_target` as this is a fork-based repository
+  pull_request_target:
     types:
       - opened
       - edited

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,7 +1,8 @@
 name: "Lint PR"
 
 on:
-  pull_request_target:
+  # pull_request_target:
+  pull_request:
     types:
       - opened
       - edited

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,9 +1,9 @@
 name: "Lint PR"
 
 on:
-  # pull_request:
-  # triggers on `pull_request_target` as this is a fork-based repository
-  pull_request_target:
+  pull_request:
+    # triggers on `pull_request_target` as this is a fork-based repository
+    # pull_request_target:
     types:
       - opened
       - edited


### PR DESCRIPTION
Triggers a pull request linter to validate PR title on PRs coming from forked repositories.
This way we automatically ensure all PRs follow [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/).

P.S.: leaving the PR with the `Invalid PR title` prefix just to show how validation works. PR title will be updated after PR is approved.